### PR TITLE
feat: new flag to show stdin as an option in the help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Options:
   - `envPrefix` - A prefix to use for environment variables. If provided, the library will look for environment variables that start with the prefix and use them as defaults for the arguments. For example, if the prefix is `MY_APP`, the library will look for environment variables like `MY_APP_REGIONS`, `MY_APP_ACCOUNT`, etc. These variables will be validated just like the CLI arguments. Any values provided on the CLI will override the environment variables.
   - `operandsName` - The name of the operands. This is used in the help text. By default, this is `operand`.
   - `requireSubcommand` - If true, a subcommand is required. By default, this is false.
+  - `allowOperandsFromStdin` - If true, the help text will include a usage example of reading operands from stdin. By default, this is false.
 
 ## Reading from stdin
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -181,6 +181,13 @@ export interface AdditionalCliArguments {
    */
 
   expectOperands?: boolean
+
+  /**
+   * Allow operands from standard input. If true, the help will include a note about reading operands from standard input.
+   *
+   * Defaults to false
+   */
+  allowOperandsFromStdin?: boolean
 }
 
 export type SelectedCommandWithArgs<
@@ -766,6 +773,9 @@ export function printHelpContents<
     const flags = anyGlobalFlags || anyCommandFlags ? ' [flags]' : ''
 
     let usageString = `Usage: ${command} ${selectedSubcommand} [options]${flags}${operandsString}`
+    if (additionalArgs?.allowOperandsFromStdin) {
+      usageString += `\n       <${operandsName}s to stdout> | ${command} ${selectedSubcommand} [options]${flags}`
+    }
 
     console.log(usageString)
     console.log(`\n${subcommands[selectedSubcommand].description}`)
@@ -779,15 +789,19 @@ export function printHelpContents<
 
     const flags = anyGlobalFlags || anyCommandFlags ? ' [flags]' : ''
 
-    let usageString = `Usage: ${command}`
+    let singleUseString = `${command}`
     const subcommandKeys = Object.keys(subcommands)
     if (subcommandKeys.length > 0 && additionalArgs?.requireSubcommand) {
-      usageString += ' <subcommand>'
+      singleUseString += ' <subcommand>'
     } else if (subcommandKeys.length > 0) {
-      usageString += ' [subcommand]'
+      singleUseString += ' [subcommand]'
     }
 
-    usageString += ` [options]${flags}${operandsString}`
+    singleUseString += ` [options]${flags}`
+    let usageString = `Usage: ${singleUseString}${operandsString}`
+    if (additionalArgs?.allowOperandsFromStdin) {
+      usageString += `\n       <${operandsName}s to stdout> | ${singleUseString}`
+    }
 
     console.log(usageString)
 

--- a/src/demo/four.ts
+++ b/src/demo/four.ts
@@ -1,0 +1,41 @@
+import { parseCliArguments } from '../cli.js'
+
+/*
+
+  npx tsx src/demo/three.ts
+
+*/
+
+const args = parseCliArguments(
+  'four',
+  {},
+  {
+    verbose: {
+      description: 'Print more information',
+      character: 'v',
+      values: 'none'
+    },
+    type: {
+      description: 'Type of the file',
+      type: 'enum',
+      validValues: ['json', 'yaml', 'xml'],
+      values: 'single'
+    },
+    formats: {
+      description: 'Type of the file',
+      type: 'enum',
+      validValues: ['gif', 'jpg', 'png', 'svg'],
+      values: 'multiple'
+    }
+  },
+  {
+    showHelpIfNoArgs: true,
+    version: '1.0.0'
+  }
+)
+
+console.log(JSON.stringify(args, null, 2))
+
+console.log(args.args.verbose)
+console.log(args.args.type)
+console.log(args.args.formats)


### PR DESCRIPTION
Adding a new option `allowOperandsFromStdin` that updates the help output for users. 