### PR TITLE
fix: readStdin leaves open resources that can cause a process to hang

### DIFF
--- a/src/demo/README.md
+++ b/src/demo/README.md
@@ -1,0 +1,3 @@
+# Demos
+
+These are different demos that show how to use the library. They are not included in the packaged library.

--- a/src/demo/five.ts
+++ b/src/demo/five.ts
@@ -1,0 +1,58 @@
+import { parseCliArguments } from '../cli.js'
+import { readStdin } from '../stdin.js'
+
+/*
+
+  npx tsx src/demo/five.ts
+
+*/
+
+async function run() {
+  const cli = parseCliArguments(
+    'five',
+    {},
+    {
+      verbose: {
+        description: 'Print more information',
+        character: 'v',
+        values: 'none'
+      },
+      type: {
+        description: 'Type of the file',
+        type: 'enum',
+        validValues: ['json', 'yaml', 'xml'],
+        values: 'single'
+      },
+      formats: {
+        description: 'Type of the file',
+        type: 'enum',
+        validValues: ['gif', 'jpg', 'png', 'svg'],
+        values: 'multiple'
+      },
+      readWait: {
+        description: 'The time to wait for input from stdin',
+        type: 'number',
+        values: 'single'
+      }
+    },
+    {
+      version: '1.0.0'
+    }
+  )
+
+  console.log(JSON.stringify(cli, null, 2))
+  const stdIn = await readStdin(cli.args.readWait)
+
+  console.log(stdIn)
+  console.log(cli.args.verbose)
+  console.log(cli.args.type)
+  console.log(cli.args.formats)
+}
+
+run()
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })
+  .then(() => {})
+  .finally(() => {})

--- a/src/demo/four.ts
+++ b/src/demo/four.ts
@@ -2,7 +2,7 @@ import { parseCliArguments } from '../cli.js'
 
 /*
 
-  npx tsx src/demo/three.ts
+  npx tsx src/demo/four.ts
 
 */
 

--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -16,6 +16,8 @@ export async function readStdin(readWait: number | undefined): Promise<string> {
     let data = ''
     const timeout = setTimeout(() => {
       if (data.length === 0) {
+        stdin.pause()
+        stdin.removeAllListeners('data')
         resolve(data)
       }
     }, readWait)


### PR DESCRIPTION
… when there is no input to stdin.